### PR TITLE
Updates default version to v3.4.11

### DIFF
--- a/vars/zookeeper.yml
+++ b/vars/zookeeper.yml
@@ -15,7 +15,7 @@ zookeeper_user: zookeeper
 zookeeper_group: zookeeper
 
 # the version and distribution URL
-zookeeper_version: "3.4.9"
+zookeeper_version: "3.4.11"
 zookeeper_url: "https://www.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz"
 
 # path used to access private keys (defaults to the current working directory)


### PR DESCRIPTION
This PR updates the default version installed by the playbook to v3.4.11 (the latest v3.4.x release). This update is necessary because the old version we were using (v3.4.9) is no longer available through the main Apache download site.